### PR TITLE
amend(105): Set Quorum to be 50%+1 instead of 100%

### DIFF
--- a/rule105.md
+++ b/rule105.md
@@ -7,7 +7,11 @@ Type: Mutable
 
 # Rule
 
-Every player is an eligible voter. Every eligible voter must participate in every vote on rule-changes.
+Every player is an eligible voter. Quorum for a vote is reached when more than half of all eligible voters participate in the proposed rule-change.
+
+## Original Language
+
+>Every player is an eligible voter. Every eligible voter must participate in every vote on rule-changes.
 
 # Copyright
 

--- a/rule302.md
+++ b/rule302.md
@@ -1,5 +1,5 @@
 ---
-RULE: 105
+RULE: 302
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable


### PR DESCRIPTION
- Quorum on votes requires half of all active players.
- Votes require two-thirds (2/3) to pass.

This is also impacted by rule105 that requires every eligible voter to vote on each rule-change. A proposal to make that rule mutable, then deprecated by this, seems required.
