### PR TITLE
remove rule summary from top of the scoreboard

### DIFF
--- a/SCOREBOARD.md
+++ b/SCOREBOARD.md
@@ -1,15 +1,3 @@
-## Relevant Rules
-
-> [Rule 201](https://github.com/mburns/nomic/blob/master/rule201.md): All players begin with **zero points**.
-
-> [Rule 202](https://github.com/mburns/nomic/blob/master/rule202.md): Players subtract 291 from the [ordinal number](https://en.wikipedia.org/wiki/Ordinal_number) of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the *nearest integer*.
-
-> [Rule 204](https://github.com/mburns/nomic/blob/master/rule204.md): If and when rule-changes can be adopted without unanimity, each player who voted against the winning proposals shall receive **10 points**.
-
-> [Rule 206](https://github.com/mburns/nomic/blob/master/rule206.md): When a proposed rule-change is defeated, the player who proposed it loses **10 points**.
-
-> [Rule 208](https://github.com/mburns/nomic/blob/master/rule208.md): The winner is the first player to reach +200 points.
-
 ## Players
 
 User | Points

--- a/SCOREBOARD.md
+++ b/SCOREBOARD.md
@@ -1,4 +1,4 @@
-## Players
+# Scoreboard
 
 User | Points
 ---- | ------


### PR DESCRIPTION
This removes the summary of rules in `SCOREBOARD.md`.

Summarizing rules in the README as well as these ancillary files is begging to create inconsistency and confusion.
