### PR TITLE
amend(105): Allow players to abstain, define quorum

### DIFF
--- a/rule105.md
+++ b/rule105.md
@@ -9,7 +9,25 @@ Type: Mutable
 
 Every player is an eligible voter.
 
-Every eligible voter must participate in every vote on rule-changes.
+Eligible voters may choose to participate in votes on rule-changes or abstain. If no action is taken, a voter is considered to have abstained and is neither for or against the proposal.
+
+Quorum is half of all active registered players. Votes on rule-changes take effect if and only if quorum is reached.
+
+```javascript
+let n = number of active players
+let v = number of votes
+let q = Floor(n / 2) + 1
+
+if v >= q, quorum is reached.
+```
+
+## Original Language
+
+>Every player is an eligible voter. Every eligible voter must participate in every vote on rule-changes.
+
+## Notes
+
+* [Chiark Nomic, rule 201](http://www.chiark.greenend.org.uk/~dricher/Nomic/CN/rules.html)
 
 # Copyright
 


### PR DESCRIPTION
# What

This defines Quorum required for a vote (the amount of participation amongst Players needed to certify a vote as valid) to be "more than half" of eligible voters.

Previously, all votes required 100% participation.
# Why

100% participation is impractical in this medium and sets the bar for active participation to be too high would-be casual Players.
