### PR TITLE
amend(201): Allow Players to act out of turn

### DIFF
--- a/rule201.md
+++ b/rule201.md
@@ -7,7 +7,7 @@ Type: Mutable
 
 # Rule
 
-Players shall alternate in alphabetical order by Github Username.
+Players may take their turn at any time, independent of other Players.
 
 ## Original Language
 


### PR DESCRIPTION
# What

This abandons the 'take turns alphabetically' process and allows Players to act without waiting on others.
# Why

Requiring Players to take turns in alphabetical order by username is susceptible to inactive Players stalling the game as well as boring downtime while Players wait for their turn to act again.

Fixes #8 
