### PR TITLE
Add CI linting of markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+npm-debug.log
+node_modules/

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "MD013": false,
+    "MD029": {
+      "style": "ordered"
+    },
+    "MD041": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: node_js
+script: npm run test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Github Nomic
 
 [![Join the chat at https://gitter.im/mburns/nomic](https://badges.gitter.im/mburns/nomic.svg)](https://gitter.im/mburns/nomic?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/mburns/nomic.svg?branch=master)](https://travis-ci.org/mburns/nomic)
 
 This is an instance of the game [Nomic](https://en.wikipedia.org/wiki/Nomic) driven by Github interactions:
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "nomic",
+  "version": "1.0.0",
+  "description": "Nomic is a game in which changing the rules is a move.",
+  "main": "index.js",
+  "scripts": {
+    "test": "markdownlint --config .markdownlint.json *.md"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mburns/nomic.git"
+  },
+  "keywords": [
+    "nomic"
+  ],
+  "author": "Michael Burns <michael@mirwin.net>",
+  "contributors": [{
+    "name": "Justin Gallardo",
+    "email": "justin.gallardo@gmail.com"
+  }],
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/mburns/nomic/issues"
+  },
+  "homepage": "https://github.com/mburns/nomic#readme",
+  "devDependencies": {
+    "markdownlint-cli": "0.0.3"
+  }
+}


### PR DESCRIPTION
# What

This adds a `package.json` with `npm test` configured to run `markdownlint-cli` on all Markdown files.

We will need to configure it further
# Why

Enforcing good markup will help keep the game consistent and understandable.
