### PR TITLE
Markdown lint cleanup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-## Rule-change History
+# Rule-change History
 
 Rule | Proposer | Result | Points | Date
 ---- | -------- | ------ | ------ | ----

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,5 +2,4 @@
 
 Rule | Proposer | Result | Points | Date
 ---- | -------- | ------ | ------ | ----
-| | | | 
-
+| | | |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Here are the basic set of rules that describe the parameters of the game. All ru
 1. Players vote on and submit rule-changes to evolve the game
 2. Disputes are resolved through [Call For Judgments](https://github.com/mburns/nomic/blob/master/.github/CONTRIBUTING.md#call-for-judgment) by choosing another Player as a nuetral arbitrator.
 
-*These descriptions are non-binding. See the individual rules for their specific language.*
-
 #### Ground Rules
 
 Rule | Mutable | Brief Description

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an instance of the game [Nomic](https://en.wikipedia.org/wiki/Nomic) dri
 * [Rules](https://github.com/mburns/nomic/wiki/Rules) are stored as Markdown documents
 * [Votes](https://github.com/mburns/nomic/wiki/Voting) are handled as (+1/-1) comments and discussion in [Pull Requests](https://github.com/mburns/nomic/pulls)
 
-## What is Nomic?
+## What is Nomic
 
 > "[Nomic](http://legacy.earlham.edu/~peters/writing/nomic.htm) is a game in which changing the rules is a move. In that respect it differs from almost every other game. The primary activity of Nomic is proposing changes in the rules, debating the wisdom of changing them in that way, voting on the changes, deciding what can and cannot be done afterwards, and doing it. Even this core of the game, of course, can be changed."
 > -- Peter Suber, [The Paradox of Self-Amendment](http://dash.harvard.edu/handle/1/10243418)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ This repository was inspired by a [Hacker News comment](https://news.ycombinator
 * [alokmenghrajani/nomic](https://github.com/alokmenghrajani/nomic)
 * [fkh/nomic](https://github.com/fkh/nomic)
 
-# Copyright
+## Copyright
 
 All information on this site is public domain and may be distributed or copied unless otherwise specified.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ These document's formatting was inspired by [chef-rfc](https://github.com/chef/c
 
 This repository was inspired by a [Hacker News comment](https://news.ycombinator.com/item?id=4889988) by [ChrisAcky](http://acky.vze.com/) and follows in the footsteps of other Nomic Github games:
 
-* https://github.com/aasmith/nomic
-* https://github.com/alokmenghrajani/nomic
-* https://github.com/fkh/nomic
+* [aasmith/nomic](https://github.com/aasmith/nomic)
+* [alokmenghrajani/nomic](https://github.com/alokmenghrajani/nomic)
+* [fkh/nomic](https://github.com/fkh/nomic)
 
 # Copyright
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Rule | Mutable | Brief Description
 [116](/rule116.md) | N | Whatever is not prohibited or regulated by a rule is permitted and unregulated
 
 #### Player Actions
+
 Rule | Mutable | Brief Description
 ---- | ------- | -----------------
 [105](/rule105.md) | Y | Every player is an eligible voter
@@ -52,6 +53,7 @@ Rule | Mutable | Brief Description
 [202](/rule202.md) | Y | One turn consists of: (1) proposing one rule-change and having it voted on, and (2) adding a [computed value](/rule202.md) to your score
 
 #### Rule-changes
+
 Rule | Mutable | Brief Description
 ---- | ------- | -----------------
 [111](/rule111.md) | N | If a rule-change as proposed is unclear then the other players may suggest amendments or argue against the proposal before the vote.
@@ -59,6 +61,7 @@ Rule | Mutable | Brief Description
 [205](/rule205.md) | Y | An adopted rule-change takes full effect at the moment of the completion of the vote that adopted it.
 
 #### End-game
+
 Rule | Mutable | Brief Description
 ---- | ------- | -----------------
 [208](/rule208.md) | Y | The **winner** is of the Round first Player to achieve 200 (positive) points.

--- a/rule103.md
+++ b/rule103.md
@@ -7,7 +7,7 @@ Type: Immutable
 
 # Rule
 
-A rule-change is any of the following: 
+A rule-change is any of the following:
 
 1. the enactment, repeal, or amendment of a mutable rule;
 2. the enactment, repeal, or amendment of an amendment of a mutable rule; or

--- a/rule213.md
+++ b/rule213.md
@@ -7,9 +7,7 @@ Type: Mutable
 
 # Rule
 
-If the rules are changed so that further play is impossible, or if the legality of a move cannot be determined with finality, or if by the Judge's best reasoning, not overruled, a move appears equally legal and illegal, then the first player unable to complete a turn is the winner.
-
-**This rule takes precedence over every other rule determining the winner.**
+If the rules are changed so that further play is impossible, or if the legality of a move cannot be determined with finality, or if by the Judge's best reasoning, not overruled, a move appears equally legal and illegal, then the first player unable to complete a turn is the winner. **This rule takes precedence over every other rule determining the winner.**
 
 # Copyright
 

--- a/rule303.md
+++ b/rule303.md
@@ -53,6 +53,7 @@ For judgments:
 CFJ(<judgment number>): Short, imperative description of the CFJ
 
 A longer description of the claim or judgment if it is needed. The short description should be limited to 80 characters or less.
+```
 
 Example:
 

--- a/rule303.md
+++ b/rule303.md
@@ -11,7 +11,8 @@ All rule proposals and amendments must adhere to the commit format set
 forth below.
 
 For proposals:
-```
+
+```markdown
 propose(<rule number>): Short, imperative description of the new rule.
 
 A longer description of the rule if it is needed. The short description
@@ -19,7 +20,8 @@ should be limited to 72 characters or less.
 ```
 
 Example:
-```
+
+```markdown
 propose(303): Define commit message format.
 
 This rule defines a standard format for commit messages used when
@@ -27,7 +29,8 @@ proposing new rules or amending existing rules.
 ```
 
 For amendments:
-```
+
+```markdown
 amend(<rule number>): Short, imperative description of the rule change.
 
 
@@ -36,7 +39,8 @@ should be limited to 72 characters or less.
 ```
 
 Example:
-```
+
+```markdown
 amend(303): Increase the maximum characters in first line of commit msg.
 
 This increases the maximum length of the first line in a commit message
@@ -45,12 +49,14 @@ to 80 characters up from 72 characters.
 
 For judgments:
 
-```
+```markdown
 CFJ(<judgment number>): Short, imperative description of the CFJ
 
 A longer description of the claim or judgment if it is needed. The short description should be limited to 80 characters or less.
+
 Example:
-```
+
+```markdown
 CFJ(1): Player Foo violated Rule ###
 
 I claim that Player Foo violated Rule ### when X, Y and Z occurred.

--- a/rule303.md
+++ b/rule303.md
@@ -33,7 +33,6 @@ For amendments:
 ```markdown
 amend(<rule number>): Short, imperative description of the rule change.
 
-
 A longer description of the rule if it is needed. The short description
 should be limited to 72 characters or less.
 ```
@@ -62,7 +61,6 @@ CFJ(1): Player Foo violated Rule ###
 
 I claim that Player Foo violated Rule ### when X, Y and Z occurred.
 ```
-
 
 # Copyright
 


### PR DESCRIPTION
# What

This is the set of suggested fixes from `markdownlint-cli`. Currently markdownlint doesn't load a config file from a [well-known path](https://github.com/igorshubovych/markdownlint-cli/issues/3) so `npm test` manually sets it.
# Why

With #25, this makes the repository complete a successful `npm test`, which means it can be relied upon going forward.
# Notes
- [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md)
