### PR TITLE
amend(207): Clarify player voting rules.

### DIFF
--- a/rule207.md
+++ b/rule207.md
@@ -7,7 +7,13 @@ Type: Mutable
 
 # Rule
 
-Each player always has exactly one vote.
+Each player always has exactly one vote. They can change their vote on a proposal as many times as they would like. When quorum is reached, the Player's most recent vote will be counted.
+
+Upon submission of a rule-change, the proposing Player automatically casts an immutable +1 vote for their proposal.
+
+## Original Language
+
+> Each player always has exactly one vote.
 
 # Copyright
 

--- a/rule207.md
+++ b/rule207.md
@@ -7,7 +7,7 @@ Type: Mutable
 
 # Rule
 
-Each player always has exactly one vote. They can change their vote on a proposal as many times as they would like. When quorum is reached, the Player's most recent vote will be counted.
+Each player always has exactly one vote.
 
 Upon submission of a rule-change, the proposing Player automatically casts an immutable +1 vote for their proposal.
 


### PR DESCRIPTION
# What

~~This clarifies the language specifying how many votes a user has.~~ It also explicitly states that by proposing a rule-change a user implicitly approves their own submission.
# Why

~~In the spirit of iteration, players should be given the opportunity to change their minds before a final vote is counted.~~ It should also be made clear that a user should be only submit proposals for rule-changes they support.
