### PR TITLE
Whitespace cleanup to simplify diffs

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
     "MD029": {
       "style": "ordered"
     },
+    "MD036": false,
     "MD041": false
 }

--- a/rule104.md
+++ b/rule104.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-All rule-changes proposed in the proper way shall be voted on. They will be adopted if and only if they receive the required number of votes.
+All rule-changes proposed in the proper way shall be voted on.
+
+They will be adopted if and only if they receive the required number of votes.
 
 # Copyright
 

--- a/rule105.md
+++ b/rule105.md
@@ -7,7 +7,9 @@ Type: Mutable
 
 # Rule
 
-Every player is an eligible voter. Every eligible voter must participate in every vote on rule-changes.
+Every player is an eligible voter.
+
+Every eligible voter must participate in every vote on rule-changes.
 
 # Copyright
 

--- a/rule106.md
+++ b/rule106.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-All proposed rule-changes shall be written down before they are voted on. If they are adopted, they shall guide play in the form in which they were voted on.
+All proposed rule-changes shall be written down before they are voted on.
+
+If they are adopted, they shall guide play in the form in which they were voted on.
 
 # Copyright
 

--- a/rule107.md
+++ b/rule107.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-No rule-change may take effect earlier than the moment of the completion of the vote that adopted it, even if its wording explicitly states otherwise. No rule-change may have retroactive application.
+No rule-change may take effect earlier than the moment of the completion of the vote that adopted it, even if its wording explicitly states otherwise.
+
+No rule-change may have retroactive application.
 
 # Copyright
 

--- a/rule108.md
+++ b/rule108.md
@@ -7,9 +7,13 @@ Type: Immutable
 
 # Rule
 
-Each proposed rule-change shall be given a number for reference. The numbers shall begin with 301, and each rule-change proposed in the proper way shall receive the next successive integer, whether or not the proposal is adopted.
+Each proposed rule-change shall be given a number for reference.
 
-If a rule is repealed and reenacted, it receives the number of the proposal to reenact it. If a rule is amended or transmuted, it receives the number of the proposal to amend or transmute it. If an amendment is amended or repealed, the entire rule of which it is a part receives the number of the proposal to amend or repeal the amendment.
+The numbers shall begin with 301, and each rule-change proposed in the proper way shall receive the next successive integer, whether or not the proposal is adopted.
+
+* If a rule is repealed and reenacted, it receives the number of the proposal to reenact it.
+* If a rule is amended or transmuted, it receives the number of the proposal to amend or transmute it.
+* If an amendment is amended or repealed, the entire rule of which it is a part receives the number of the proposal to amend or repeal the amendment.
 
 # Copyright
 

--- a/rule109.md
+++ b/rule109.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-Rule-changes that transmute immutable rules into mutable rules may be adopted if and only if the vote is unanimous among the eligible voters. Transmutation shall not be implied, but must be stated explicitly in a proposal to take effect.
+Rule-changes that transmute immutable rules into mutable rules may be adopted if and only if the vote is unanimous among the eligible voters.
+
+Transmutation shall not be implied, but must be stated explicitly in a proposal to take effect.
 
 # Copyright
 

--- a/rule110.md
+++ b/rule110.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-In a conflict between a mutable and an immutable rule, the immutable rule takes precedence and the mutable rule shall be entirely void. For the purposes of this rule a proposal to transmute an immutable rule does not "conflict" with that immutable rule.
+In a conflict between a mutable and an immutable rule, the immutable rule takes precedence and the mutable rule shall be entirely void.
+
+For the purposes of this rule a proposal to transmute an immutable rule does not "conflict" with that immutable rule.
 
 # Copyright
 

--- a/rule111.md
+++ b/rule111.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-If a rule-change as proposed is unclear, ambiguous, paradoxical, or destructive of play, or if it arguably consists of two or more rule-changes compounded or is an amendment that makes no difference, or if it is otherwise of questionable value, then the other players may suggest amendments or argue against the proposal before the vote. A reasonable time must be allowed for this debate. The proponent decides the final form in which the proposal is to be voted on and, unless the Judge has been asked to do so, also decides the time to end debate and vote.
+If a rule-change as proposed is unclear, ambiguous, paradoxical, or destructive of play, or if it arguably consists of two or more rule-changes compounded or is an amendment that makes no difference, or if it is otherwise of questionable value, then the other players may suggest amendments or argue against the proposal before the vote.
+
+A reasonable time must be allowed for this debate. The proponent decides the final form in which the proposal is to be voted on and, unless the Judge has been asked to do so, also decides the time to end debate and vote.
 
 # Copyright
 

--- a/rule112.md
+++ b/rule112.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-The state of affairs that constitutes winning may not be altered from achieving N points to any other state of affairs. The magnitude of N and the means of earning points may be changed, and rules that establish a winner when play cannot continue may be enacted and (while they are mutable) be amended or repealed.
+The state of affairs that constitutes winning may not be altered from achieving N points to any other state of affairs.
+
+The magnitude of N and the means of earning points may be changed, and rules that establish a winner when play cannot continue may be enacted and (while they are mutable) be amended or repealed.
 
 # Copyright
 

--- a/rule114.md
+++ b/rule114.md
@@ -7,7 +7,9 @@ Type: Immutable
 
 # Rule
 
-There must always be at least one mutable rule. The adoption of rule-changes must never become completely impermissible.
+There must always be at least one mutable rule.
+
+The adoption of rule-changes must never become completely impermissible.
 
 # Copyright
 

--- a/rule115.md
+++ b/rule115.md
@@ -7,7 +7,11 @@ Type: Immutable
 
 # Rule
 
-Rule-changes that affect rules needed to allow or apply rule-changes are as permissible as other rule-changes. Even rule-changes that amend or repeal their own authority are permissible. No rule-change or type of move is impermissible solely on account of the self-reference or self-application of a rule.
+Rule-changes that affect rules needed to allow or apply rule-changes are as permissible as other rule-changes.
+
+Even rule-changes that amend or repeal their own authority are permissible.
+
+No rule-change or type of move is impermissible solely on account of the self-reference or self-application of a rule.
 
 # Copyright
 

--- a/rule203.md
+++ b/rule203.md
@@ -7,6 +7,10 @@ Type: Mutable
 
 # Rule
 
+A rule-change is adopted if and only if the vote is a simple majority among the eligible voters.
+
+## Original Language
+
 A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority.
 
 # Copyright

--- a/rule213.md
+++ b/rule213.md
@@ -7,7 +7,9 @@ Type: Mutable
 
 # Rule
 
-If the rules are changed so that further play is impossible, or if the legality of a move cannot be determined with finality, or if by the Judge's best reasoning, not overruled, a move appears equally legal and illegal, then the first player unable to complete a turn is the winner. **This rule takes precedence over every other rule determining the winner.**
+If the rules are changed so that further play is impossible, or if the legality of a move cannot be determined with finality, or if by the Judge's best reasoning, not overruled, a move appears equally legal and illegal, then the first player unable to complete a turn is the winner.
+
+**This rule takes precedence over every other rule determining the winner.**
 
 # Copyright
 


### PR DESCRIPTION
# What

This is a no-effect change intended to make the rules easier to read and diff.
- Adds whitespace and some markdown
- Adds bullet lists for run-own paragraphs
- excuses a rule that requires entires sentences being emphasized to [only be represented as a Header](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md#md036---emphasis-used-instead-of-a-header)
