### PR TITLE
amend(203): Require votes receive 2/3 votes to pass

### DIFF
--- a/rule308.md
+++ b/rule308.md
@@ -1,0 +1,31 @@
+---
+RULE: 308
+Author: Peter Suber <peters@earlham.edu>
+Status: Accepted
+Type: Mutable
+---
+
+# Rule
+
+A rule-change is adopted if and only if the vote is at least two-thirds in the affirmative (`+1`) among eligible voters.
+
+```javascript
+let v = number of votes
+let a = number of affirmative votes
+
+let p = a / v
+
+if p >= (2/3), proposal is adopted
+```
+
+## Original Language
+
+>A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority.
+
+## Notes
+
+* [CharNomic #109](http://www.tesseract.org/nomic/ruleset.html#NewRules)
+
+# Copyright
+
+[Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber


### PR DESCRIPTION
# What

Require that successful proposals receive at least `2/3s` of the votes cast.
# Why

With quorum defined in #22, having a `50% + 1` voter support on a `50% + 1` eligible vote participation means a group of about 25% of the active players could collude to pass rule-changes through inaction of other players.
# Notes
- [201](http://www.chiark.greenend.org.uk/~dricher/Nomic/CN/rules.html)
