### PR TITLE
go-nomic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 npm-debug.log
 node_modules/
+nomic

--- a/nomic.go
+++ b/nomic.go
@@ -188,7 +188,7 @@ func readRule(filename string, dir string) *Rule {
 		switch step {
 		case "Text":
 			// TODO : remove hack by prepending 4 spaces directly to the Rule text
-			body.Text = body.Text + "    " + str
+			body.Text = body.Text + "> " + str
 		case "Example":
 			body.Examples = body.Examples + str
 		case "Original":
@@ -235,7 +235,7 @@ func writeRules(rules []Rule) {
 	dat = "# Rules\n\n"
 
 	for _, v := range rules {
-		dat = dat + fmt.Sprintf("[#%d](rules/rule%d.md): %s\n", v.Metadata.Number, v.Metadata.Number, v.Body.Text)
+		dat = dat + fmt.Sprintf("[#%d](rules/rule%d.md): %s \n%s\n", v.Metadata.Number, v.Metadata.Number, v.Metadata.Tags, v.Body.Text)
 	}
 	err := ioutil.WriteFile("RULES.md", []byte(dat), 0644)
 	check(err)

--- a/nomic.go
+++ b/nomic.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// This helper will streamline our error checks below.
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+// Metadata of a Rule
+type Metadata struct {
+	Number int
+	Author string
+	Status string
+	Type   string
+}
+
+// Body is the actual text of the rule
+type Body struct {
+	Text       string
+	Examples   string
+	Original   string
+	References string
+}
+
+// Rule components of a given rule in Nomic
+type Rule struct {
+	Metadata  *Metadata
+	Body      *Body
+	Copyright string
+}
+
+// Split on : char and get first value
+func getMetaKey(line []byte) string {
+	k := bytes.Split(line, []byte(": "))[0]
+
+	// Cast byte[] to string
+	return fmt.Sprintf("%s", k)
+}
+
+// Split on : char and get second value
+func getMetaVal(line []byte) string {
+	k := bytes.Split(line, []byte(": "))[1]
+
+	// Cast byte[] to string
+	return fmt.Sprintf("%s", k)
+}
+
+// Check whether a rule is mutable or not
+func isMutable(rule Rule) bool {
+	if rule.Metadata.Type == "Mutable" {
+		return true
+	}
+
+	return false
+}
+
+// Count the number of mutable rules
+func countMutable(rules []Rule) int {
+	var count int
+
+	for _, v := range rules {
+		if isMutable(v) {
+			count++
+		}
+	}
+	return count
+}
+
+// Create a new Rule struct
+func newRule(metadata *Metadata, body *Body, copyright string) *Rule {
+	rule := &Rule{
+		Metadata:  metadata,
+		Body:      body,
+		Copyright: copyright,
+	}
+	return rule
+}
+
+// Read a single markdown file, parse as a Rule
+func readRule(filename string, dir string) *Rule {
+	path := dir + filename
+	file, err := os.Open(path)
+	check(err)
+
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+
+	// constituent parts of a rule
+	metadata := &Metadata{}
+	body := &Body{}
+	var copyright string
+
+	// read lind-by-line until second `--`
+	count := 0
+	for {
+		line, _, err := reader.ReadLine()
+
+		if err == io.EOF {
+			break
+		}
+
+		if bytes.Contains(line, []byte("---")) {
+			count++
+		}
+
+		if count > 1 {
+			break
+		}
+
+		if bytes.Contains(line, []byte("RULE")) {
+			if s, err := strconv.Atoi(getMetaVal(line)); err == nil {
+				metadata.Number = s
+			}
+			check(err)
+		}
+
+		if bytes.Contains(line, []byte("Author")) {
+			metadata.Author = getMetaVal(line)
+		}
+
+		if bytes.Contains(line, []byte("Status")) {
+			metadata.Status = getMetaVal(line)
+		}
+
+		if bytes.Contains(line, []byte("Type")) {
+			metadata.Type = getMetaVal(line)
+		}
+	}
+
+	step := "Text"
+	for {
+		line, _, err := reader.ReadLine()
+
+		if err == io.EOF {
+			break
+		}
+
+		// convert line from byte array to string
+		str := fmt.Sprintf("%s\n", line)
+
+		// grab (sub)heading name
+		r := regexp.MustCompile("^#+ ([A-Za-z]+)")
+		check(err)
+		m := r.FindStringSubmatch(str)
+
+		if len(m) > 0 {
+			step = m[1]
+			if step == "Rule" {
+				step = "Text"
+			}
+		}
+		// step = (sub)heading
+
+		// append line to correct string
+		switch step {
+		case "Text":
+			body.Text = body.Text + str
+		case "Example":
+			body.Examples = body.Examples + str
+		case "Original":
+			body.Original = body.Original + str
+		case "References":
+			body.References = body.References + str
+		case "Copyright":
+			copyright = copyright + str
+		default:
+			panic("unrecognized escape character")
+		}
+	}
+
+	rule := newRule(metadata, body, copyright)
+
+	return rule
+}
+
+// gather summary of all rule text
+func getRules(dir string) []Rule {
+	files, err := ioutil.ReadDir(dir)
+	check(err)
+
+	ruleset := []Rule{}
+
+	for _, file := range files {
+		// improve the filename check. /^rule[0-9]*\.md$/
+		if strings.HasPrefix(file.Name(), "rule") {
+			// fmt.Println(file.Name())
+			r := readRule(file.Name(), dir)
+			ruleset = append(ruleset, *r)
+		}
+	}
+	return ruleset
+}
+
+// write out all rule text to single RULES.md file
+func writeRules(rules []Rule) {
+	var dat string
+
+	// TODO :  concat all rule.Body.Text
+	dat = "# Rules\n\n"
+	for _, v := range rules {
+		dat = dat + fmt.Sprintf("### [%d](rules/rule%d.md)\n%s\n\n", v.Metadata.Number, v.Metadata.Number, v.Body.Text)
+	}
+	err := ioutil.WriteFile("RULES.md", []byte(dat), 0644)
+	check(err)
+}
+
+func getUsers() {
+
+}
+
+// read CHANGELOG, generate user scores
+func getScores() {
+	// getUsers
+	// read CHANGELOG
+}
+
+// iterate over users,scores and output SCOREBOARD.md
+func writeScoreboard() {
+	var dat string
+
+	// getScores()
+
+	dat = `# Scoreboard
+
+	User | Points
+	---- | ------
+	`
+
+	// TODO : list users & scores
+
+	err := ioutil.WriteFile("SCOREBOARD.md", []byte(dat), 0644)
+	check(err)
+}
+
+func main() {
+
+	var dir = flag.String("rulesDir", "rules/", "The directory where rules are stored.")
+	// var noop = flag.Bool("noop", false, "No-op mode. Do not write out data.")
+
+	flag.Parse()
+
+	rules := getRules(*dir)
+	writeRules(rules)
+	// writeScoreboard()
+
+	m := countMutable(rules)
+	if m < 25 {
+		fmt.Printf("There are %d mutable rules\n", m)
+
+	} else {
+		panic("There are too many immutable rules")
+	}
+}

--- a/nomic.go
+++ b/nomic.go
@@ -160,6 +160,14 @@ func readRule(filename string, dir string) *Rule {
 		// convert line from byte array to string
 		str := fmt.Sprintf("%s\n", line)
 
+		// eat blank lines
+		// rn := regexp.MustCompile("^$")
+		// check(err)
+		// n := rn.FindStringSubmatch(str)
+		// if len(n) > 0 {
+		// 	continue
+		// }
+
 		// grab (sub)heading name
 		r := regexp.MustCompile("^#+ ([A-Za-z]+)")
 		check(err)
@@ -179,7 +187,8 @@ func readRule(filename string, dir string) *Rule {
 		// append line to correct string
 		switch step {
 		case "Text":
-			body.Text = body.Text + str
+			// TODO : remove hack by prepending 4 spaces directly to the Rule text
+			body.Text = body.Text + "    " + str
 		case "Example":
 			body.Examples = body.Examples + str
 		case "Original":
@@ -189,7 +198,9 @@ func readRule(filename string, dir string) *Rule {
 		case "Copyright":
 			copyright = copyright + str
 		default:
-			panic("unrecognized escape character")
+			body.Examples = body.Examples + str
+
+			// panic("unrecognized escape character")
 		}
 	}
 
@@ -222,8 +233,9 @@ func writeRules(rules []Rule) {
 
 	// TODO :  concat all rule.Body.Text
 	dat = "# Rules\n\n"
+
 	for _, v := range rules {
-		dat = dat + fmt.Sprintf("### [%d](rules/rule%d.md)\n\n```%s```\n\n", v.Metadata.Number, v.Metadata.Number, v.Body.Text)
+		dat = dat + fmt.Sprintf("[#%d](rules/rule%d.md): %s\n", v.Metadata.Number, v.Metadata.Number, v.Body.Text)
 	}
 	err := ioutil.WriteFile("RULES.md", []byte(dat), 0644)
 	check(err)

--- a/nomic.go
+++ b/nomic.go
@@ -277,6 +277,33 @@ func getTag(rules []Rule, tag string) {
 
 }
 
+func AppendIfMissing(slice []string, s string) []string {
+	for _, v := range slice {
+		if v == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}
+
+func writeAuthors(rules []Rule) {
+	var dat string
+	var authors []string
+
+	// unique list of rule authors
+	for _, v := range rules {
+		authors = AppendIfMissing(authors, v.Metadata.Author)
+	}
+
+	dat = "# Authors\n\n"
+	for _, v := range authors {
+		dat = dat + fmt.Sprintf("%s\n", v)
+	}
+
+	err := ioutil.WriteFile("AUTHORS.md", []byte(dat), 0644)
+	check(err)
+}
+
 // read CHANGELOG, generate user scores
 func getScores() {
 	// getUsers
@@ -317,6 +344,7 @@ func main() {
 
 	rules := getRules(dir)
 	writeRules(rules)
+	writeAuthors(rules)
 
 	if tag != "" {
 		getTag(rules, tag)


### PR DESCRIPTION
fixes #9 

# What

`go` script to enforce rules, summaries, and score keeping.

# TODO
- [x] parse the sections and metadata of each `rule*.md` file.
- [x] Concatenate, format, and write out `RULES.md` summary page

## Future Work
- [ ] reads `HISTORY.md` and calculates scores, writes out `SCOREBOARD.md`
- [ ] handle github webhooks and tally vote scores based on comments
- [ ] write out (append-only) `HISTORY.md`
- [ ] create a new proposal or judgment from a template

# Why

To eventually automate the referee of the game via CI/CD services.
