### PR TITLE
add Tags to rules metadata

### DIFF
--- a/rules/rule101.md
+++ b/rules/rule101.md
@@ -3,6 +3,7 @@ RULE: 101
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: meta, init
 ---
 
 # Rule

--- a/rules/rule102.md
+++ b/rules/rule102.md
@@ -8,7 +8,7 @@ Tags: meta, init
 
 # Rule
 
-Initially rules in the 100's are immutable and rules in the 200's are mutable.
+Initially rules in the `100`'s are immutable and rules in the `200`'s are mutable.
 
 Rules subsequently enacted or transmuted (that is, changed from immutable to mutable or vice versa) may be immutable or mutable regardless of their numbers, and rules in the Initial Set may be transmuted regardless of their numbers.
 

--- a/rules/rule102.md
+++ b/rules/rule102.md
@@ -3,6 +3,7 @@ RULE: 102
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: meta, init
 ---
 
 # Rule

--- a/rules/rule103.md
+++ b/rules/rule103.md
@@ -3,6 +3,7 @@ RULE: 103
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, init
 ---
 
 # Rule

--- a/rules/rule104.md
+++ b/rules/rule104.md
@@ -3,6 +3,7 @@ RULE: 104
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, vote
 ---
 
 # Rule

--- a/rules/rule106.md
+++ b/rules/rule106.md
@@ -3,6 +3,7 @@ RULE: 106
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change
 ---
 
 # Rule

--- a/rules/rule107.md
+++ b/rules/rule107.md
@@ -3,6 +3,7 @@ RULE: 107
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, vote
 ---
 
 # Rule

--- a/rules/rule108.md
+++ b/rules/rule108.md
@@ -3,13 +3,14 @@ RULE: 108
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change
 ---
 
 # Rule
 
 Each proposed rule-change shall be given a number for reference.
 
-The numbers shall begin with 301, and each rule-change proposed in the proper way shall receive the next successive integer, whether or not the proposal is adopted.
+The numbers shall begin with `301`, and each rule-change proposed in the proper way shall receive the next successive integer, whether or not the proposal is adopted.
 
 * If a rule is repealed and reenacted, it receives the number of the proposal to reenact it.
 * If a rule is amended or transmuted, it receives the number of the proposal to amend or transmute it.

--- a/rules/rule109.md
+++ b/rules/rule109.md
@@ -3,6 +3,7 @@ RULE: 109
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, vote
 ---
 
 # Rule

--- a/rules/rule110.md
+++ b/rules/rule110.md
@@ -3,6 +3,7 @@ RULE: 110
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: meta
 ---
 
 # Rule

--- a/rules/rule111.md
+++ b/rules/rule111.md
@@ -3,6 +3,7 @@ RULE: 111
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, judge, vote
 ---
 
 # Rule

--- a/rules/rule112.md
+++ b/rules/rule112.md
@@ -3,6 +3,7 @@ RULE: 112
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: endgame, point
 ---
 
 # Rule

--- a/rules/rule112.md
+++ b/rules/rule112.md
@@ -8,9 +8,9 @@ Tags: endgame, point
 
 # Rule
 
-The state of affairs that constitutes winning may not be altered from achieving N points to any other state of affairs.
+The state of affairs that constitutes winning may not be altered from achieving `N` points to any other state of affairs.
 
-The magnitude of N and the means of earning points may be changed, and rules that establish a winner when play cannot continue may be enacted and (while they are mutable) be amended or repealed.
+The magnitude of `N` and the means of earning points may be changed, and rules that establish a winner when play cannot continue may be enacted and (while they are mutable) be amended or repealed.
 
 # Copyright
 

--- a/rules/rule113.md
+++ b/rules/rule113.md
@@ -3,6 +3,7 @@ RULE: 113
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: endgame, player
 ---
 
 # Rule

--- a/rules/rule114.md
+++ b/rules/rule114.md
@@ -3,6 +3,7 @@ RULE: 114
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change, meta
 ---
 
 # Rule

--- a/rules/rule115.md
+++ b/rules/rule115.md
@@ -3,6 +3,7 @@ RULE: 115
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: change
 ---
 
 # Rule

--- a/rules/rule116.md
+++ b/rules/rule116.md
@@ -3,6 +3,7 @@ RULE: 116
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: meta
 ---
 
 # Rule

--- a/rules/rule201.md
+++ b/rules/rule201.md
@@ -3,6 +3,7 @@ RULE: 201
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: player
 ---
 
 # Rule

--- a/rules/rule202.md
+++ b/rules/rule202.md
@@ -3,6 +3,7 @@ RULE: 202
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: point
 ---
 
 # Rule
@@ -10,15 +11,15 @@ Type: Mutable
 One turn consists of two parts in this order:
 
 1. Proposing one rule-change and having it voted on, and
-2. Subtracting 291 from the ordinal number of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the nearest integer.
+2. Subtracting `291` from the ordinal number of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the nearest integer.
 
-    (This yields a number between 0 and 10 for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
+    (This yields a number between `0` and `10` for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
 
 ## Original Language
 
 >One turn consists of two parts in this order: (1) proposing one rule-change and having it voted on, and (2) throwing one die once and adding the number of points on its face to one's score.
 >
->In mail and computer games, instead of throwing a die, players subtract 291 from the ordinal number of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the nearest integer. (This yields a number between 0 and 10 for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
+>In mail and computer games, instead of throwing a die, players subtract `291` from the ordinal number of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the nearest integer. (This yields a number between `0` and `10` for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
 
 # Copyright
 

--- a/rules/rule203.md
+++ b/rules/rule203.md
@@ -3,6 +3,7 @@ RULE: 203
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: vote
 ---
 
 # Rule

--- a/rules/rule204.md
+++ b/rules/rule204.md
@@ -3,6 +3,7 @@ RULE: 204
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: point, vote
 ---
 
 # Rule

--- a/rules/rule205.md
+++ b/rules/rule205.md
@@ -3,6 +3,7 @@ RULE: 205
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: change
 ---
 
 # Rule

--- a/rules/rule206.md
+++ b/rules/rule206.md
@@ -3,6 +3,7 @@ RULE: 206
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: point
 ---
 
 # Rule

--- a/rules/rule207.md
+++ b/rules/rule207.md
@@ -10,7 +10,7 @@ Tags: vote
 
 Each player always has exactly one vote.
 
-Upon submission of a rule-change, the proposing Player automatically casts an immutable +1 vote for their proposal.
+Upon submission of a rule-change, the proposing Player automatically casts an immutable `+1` vote for their proposal.
 
 ## Original Language
 

--- a/rules/rule207.md
+++ b/rules/rule207.md
@@ -3,6 +3,7 @@ RULE: 207
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: vote
 ---
 
 # Rule

--- a/rules/rule208.md
+++ b/rules/rule208.md
@@ -8,13 +8,13 @@ Tags: endgame
 
 # Rule
 
-The winner is the first player to achieve 200 (positive) points.
+The winner is the first player to achieve `200` (positive) points.
 
 ## Original Language
 
->The winner is the first player to achieve 100 (positive) points.
+>The winner is the first player to achieve `100` (positive) points.
 >
->In mail and computer games, the winner is the first player to achieve 200 (positive) points.
+>In mail and computer games, the winner is the first player to achieve `200` (positive) points.
 
 # Copyright
 

--- a/rules/rule208.md
+++ b/rules/rule208.md
@@ -3,6 +3,7 @@ RULE: 208
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: endgame
 ---
 
 # Rule

--- a/rules/rule209.md
+++ b/rules/rule209.md
@@ -8,7 +8,7 @@ Tags: meta
 
 # Rule
 
-At no time may there be more than 25 mutable rules.
+At no time may there be more than `25` mutable rules.
 
 # Copyright
 

--- a/rules/rule209.md
+++ b/rules/rule209.md
@@ -3,6 +3,7 @@ RULE: 209
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: meta
 ---
 
 # Rule

--- a/rules/rule210.md
+++ b/rules/rule210.md
@@ -3,6 +3,7 @@ RULE: 210
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: meta
 ---
 
 # Rule

--- a/rules/rule211.md
+++ b/rules/rule211.md
@@ -3,6 +3,7 @@ RULE: 211
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: meta
 ---
 
 # Rule

--- a/rules/rule212.md
+++ b/rules/rule212.md
@@ -3,6 +3,7 @@ RULE: 212
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: judge, vote
 ---
 
 # Rule

--- a/rules/rule213.md
+++ b/rules/rule213.md
@@ -3,6 +3,7 @@ RULE: 213
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: endgame
 ---
 
 # Rule

--- a/rules/rule301.md
+++ b/rules/rule301.md
@@ -3,6 +3,7 @@ RULE: 301
 Author: Michael Burns <michael@mirwin.net>
 Status: Draft
 Type: Mutable
+Tags: endgame
 ---
 
 # Rule

--- a/rules/rule303.md
+++ b/rules/rule303.md
@@ -1,8 +1,9 @@
 ---
 RULE: 303
 Author: Justin Gallardo <justin.gallardo@gmail.com>
-Status: Draft
+Status: Accepted
 Type: Mutable
+Tags: meta, change
 ---
 
 # Rule

--- a/rules/rule308.md
+++ b/rules/rule308.md
@@ -3,6 +3,7 @@ RULE: 308
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Mutable
+Tags: vote
 ---
 
 # Rule

--- a/rules/rule309.md
+++ b/rules/rule309.md
@@ -3,6 +3,7 @@ RULE: 309
 Author: Peter Suber <peters@earlham.edu>
 Status: Accepted
 Type: Immutable
+Tags: player, vote
 ---
 
 # Rule


### PR DESCRIPTION
# What

Update the markdown preamble/header section to include a Tags field.

## Taxonomy

* `change`
* `vote`
* `meta`
* `endgame`
* `player`

# Why

Sorting / classifying similar rules.
