### PR TITLE
remove Original Language section

### DIFF
--- a/rules/rule201.md
+++ b/rules/rule201.md
@@ -10,12 +10,6 @@ Tags: player
 
 Players may take their turn at any time, independent of other Players.
 
-## Original Language
-
->Players shall alternate in clockwise order, taking one whole turn apiece. Turns may not be skipped or passed, and parts of turns may not be omitted. All players begin with zero points.
->
->In mail and computer games, players shall alternate in alphabetical order by surname.
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule202.md
+++ b/rules/rule202.md
@@ -15,12 +15,6 @@ One turn consists of two parts in this order:
 
     (This yields a number between `0` and `10` for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
 
-## Original Language
-
->One turn consists of two parts in this order: (1) proposing one rule-change and having it voted on, and (2) throwing one die once and adding the number of points on its face to one's score.
->
->In mail and computer games, instead of throwing a die, players subtract `291` from the ordinal number of their proposal and multiply the result by the fraction of favorable votes it received, rounded to the nearest integer. (This yields a number between `0` and `10` for the first player, with the upper limit increasing by one each turn; more points are awarded for more popular proposals.)
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule203.md
+++ b/rules/rule203.md
@@ -10,10 +10,6 @@ Tags: vote
 
 A rule-change is adopted if and only if the vote is a simple majority among the eligible voters.
 
-## Original Language
-
-A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority.
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule207.md
+++ b/rules/rule207.md
@@ -12,10 +12,6 @@ Each player always has exactly one vote.
 
 Upon submission of a rule-change, the proposing Player automatically casts an immutable `+1` vote for their proposal.
 
-## Original Language
-
-> Each player always has exactly one vote.
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule208.md
+++ b/rules/rule208.md
@@ -10,12 +10,6 @@ Tags: endgame
 
 The winner is the first player to achieve `200` (positive) points.
 
-## Original Language
-
->The winner is the first player to achieve `100` (positive) points.
->
->In mail and computer games, the winner is the first player to achieve `200` (positive) points.
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule210.md
+++ b/rules/rule210.md
@@ -10,12 +10,6 @@ Tags: meta
 
 This rule does not apply to games by mail or computer.
 
-## Original Language
-
->Players may not conspire or consult on the making of future rule-changes unless they are team-mates.
->
->The first paragraph of this rule does not apply to games by mail or computer.
-
 # Copyright
 
 [Copyright](http://legacy.earlham.edu/~peters/copyrite.htm) © 1990, Peter Suber

--- a/rules/rule308.md
+++ b/rules/rule308.md
@@ -19,10 +19,6 @@ let p = a / v
 if p >= (2/3), proposal is adopted
 ```
 
-## Original Language
-
->A rule-change is adopted if and only if the vote is unanimous among the eligible voters. If this rule is not amended by the end of the second complete circuit of turns, it automatically changes to require only a simple majority.
-
 ## References
 
 * [CharNomic #109](http://www.tesseract.org/nomic/ruleset.html#NewRules)

--- a/rules/rule309.md
+++ b/rules/rule309.md
@@ -22,11 +22,6 @@ let q = Floor(n / 2) + 1
 if v >= q, quorum is reached.
 ```
 
-## Original Language
-
->Rule 105
->Every player is an eligible voter. Every eligible voter must participate in every vote on rule-changes.
-
 ## References
 
 * [Chiark Nomic, rule 201](http://www.chiark.greenend.org.uk/~dricher/Nomic/CN/rules.html)


### PR DESCRIPTION
# What

Removes the `Original Language` section of rules that have changed or been formatted for online gameplay.

# Why

Git gives us access to the original text on a per-revision basis.
